### PR TITLE
Proj fix

### DIFF
--- a/src/_core/components/App/AppContainer.js
+++ b/src/_core/components/App/AppContainer.js
@@ -16,6 +16,7 @@ import * as mapActions from "_core/actions/mapActions";
 import * as appStrings from "_core/constants/appStrings";
 import appConfig from "constants/appConfig";
 import MiscUtil from "_core/utils/MiscUtil";
+import MapUtil from "_core/utils/MapUtil";
 import {
     MapContainer,
     MapContextMenu,
@@ -73,6 +74,9 @@ export class AppContainer extends Component {
 
         // Perform initial browser functionality check
         this.props.checkBrowserFunctionalities();
+
+        // prep the default projection for the application
+        MapUtil.prepProjection();
 
         // load in initial data
         this.props.loadInitialData(() => {

--- a/src/_core/constants/appConfig.js
+++ b/src/_core/constants/appConfig.js
@@ -119,6 +119,12 @@ export const DEFAULT_DATE_SLIDER_RESOLUTION = DATE_SLIDER_RESOLUTIONS[3];
 
 /* MAP */
 export const DEFAULT_PROJECTION = appStrings.PROJECTIONS.latlon;
+export const DEFAULT_AVAILABLE_PROJECTIONS = [
+    appStrings.PROJECTIONS.latlon,
+    appStrings.PROJECTIONS.webmercator,
+    appStrings.PROJECTIONS.northpolar,
+    appStrings.PROJECTIONS.southpolar
+];
 export const DEFAULT_BBOX_EXTENT = [-90, -45, 90, 45];
 export const DEFAULT_MAP_EXTENT = undefined; // Ex: [-360, -90, 360, 90]
 export const DEFAULT_SCALE_UNITS = "metric";

--- a/src/_core/constants/appStrings.js
+++ b/src/_core/constants/appStrings.js
@@ -99,18 +99,43 @@ export const PROJECTIONS = {
         code: "EPSG:3413",
         proj4Def:
             "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
-        extent: [-4194304, -4194304, 4194304, 4194304]
+        extent: [-4194304, -4194304, 4194304, 4194304],
+        aliases: ["urn:ogc:def:crs:EPSG::3413"]
+    },
+    southpolar: {
+        code: "EPSG:3031",
+        proj4Def:
+            "+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+        extent: [-4194304, -4194304, 4194304, 4194304],
+        aliases: ["urn:ogc:def:crs:EPSG::3031"]
     },
     webmercator: {
         code: "EPSG:3857",
         proj4Def:
             "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs",
-        extent: [-20026376.39, -20048966.1, 20026376.39, 20048966.1]
+        extent: [-20026376.39, -20048966.1, 20026376.39, 20048966.1],
+        aliases: [
+            "EPSG:102100",
+            "EPSG:102113",
+            "EPSG:900913",
+            "urn:ogc:def:crs:EPSG:6.18:3:3857",
+            "urn:ogc:def:crs:EPSG::3857",
+            "http://www.opengis.net/gml/srs/epsg.xml#3857"
+        ]
     },
     latlon: {
         code: "EPSG:4326",
         proj4Def: "+proj=longlat +datum=WGS84 +no_defs",
-        extent: [-180, -90, 180, 90]
+        extent: [-180, -90, 180, 90],
+        aliases: [
+            "CRS:84",
+            "urn:ogc:def:crs:EPSG::4326",
+            "urn:ogc:def:crs:EPSG:6.6:4326",
+            "urn:ogc:def:crs:OGC:1.3:CRS84",
+            "urn:ogc:def:crs:OGC:2:84",
+            "http://www.opengis.net/gml/srs/epsg.xml#4326",
+            "urn:x-ogc:def:crs:EPSG:4326"
+        ]
     }
 };
 

--- a/src/_core/utils/MapUtil.js
+++ b/src/_core/utils/MapUtil.js
@@ -193,7 +193,6 @@ export default class MapUtil {
      */
     static getWmtsOptions(options) {
         try {
-            this.prepProjection();
             let parseOptions = Ol_Source_WMTS.optionsFromCapabilities(
                 options.capabilities,
                 options.options
@@ -228,36 +227,33 @@ export default class MapUtil {
      * projection data within that instance
      *
      * @static
+     * @param {object} [projection=appConfig.DEFAULT_PROJECTION] the projection configuration to be prepped
+     * - code - {string} the identifier for this projection
+     * - proj4Def - {string} the proj4js definition
+     * - extent - {array} valid extents for this projection [minx, miny, maxx, maxy]
+     * - aliases - {array} list of string aliases for this projection code
      * @returns {object} the openlayers projection object for the default projection
      * @memberof MapUtil
      */
-    static prepProjection() {
+    static prepProjection(projection = appConfig.DEFAULT_PROJECTION) {
         // define the projection for this application and reproject defaults
         Ol_Proj.setProj4(proj4js);
-        proj4js.defs(appConfig.DEFAULT_PROJECTION.code, appConfig.DEFAULT_PROJECTION.proj4Def);
 
-        // Ol3 doesn't properly handle the "urn:ogc:def:crs:OGC:1.3:CRS84"
-        // string in getCapabilities and parses it into "OGC:CRS84". This
-        // hopefully adds that as an equivalent projection
-        let epsg4326Proj = Ol_Proj.get("EPSG:4326");
-        let ogcCrs84Proj = new Ol_Proj_Projection({
-            code: "OGC:CRS84",
-            units: epsg4326Proj.getUnits(),
-            extent: epsg4326Proj.getExtent(),
-            global: epsg4326Proj.isGlobal(),
-            metersPerUnit: epsg4326Proj.getMetersPerUnit(),
-            worldExtent: epsg4326Proj.getWorldExtent(),
-            getPointResolution: function(res, point) {
-                return Ol_Proj.getPointResolution("EPSG:4326", res, point);
+        // add configured projection
+        let projDef = proj4js.defs(projection.code);
+        if (typeof proj4Def === "undefined") {
+            proj4js.defs(projection.code, projection.proj4Def);
+            Ol_Proj.get(projection.code).setExtent(projection.extent);
+        }
+
+        // load aliases
+        if (typeof projection.aliases !== "undefined") {
+            for (let i = 0; i < projection.aliases.length; ++i) {
+                proj4js.defs(projection.aliases[i], proj4js.defs(projection.code));
             }
-        });
-        Ol_Proj.addProjection(ogcCrs84Proj);
-        Ol_Proj.addEquivalentProjections([ogcCrs84Proj, epsg4326Proj]);
+        }
 
-        let mapProjection = Ol_Proj.get(appConfig.DEFAULT_PROJECTION.code);
-        mapProjection.setExtent(appConfig.DEFAULT_PROJECTION.extent);
-
-        return mapProjection;
+        return Ol_Proj.get(appConfig.DEFAULT_PROJECTION.code);
     }
 
     /**

--- a/src/_core/utils/MapUtil.js
+++ b/src/_core/utils/MapUtil.js
@@ -222,12 +222,14 @@ export default class MapUtil {
             return false;
         }
     }
+
     /**
      * Sets the proj4 instance used by openlayers and initializes the default
      * projection data within that instance
      *
      * @static
-     * @param {object} [projection=appConfig.DEFAULT_PROJECTION] the projection configuration to be prepped
+     * @param {object|array} [projectionList=appConfig.DEFAULT_AVAILABLE_PROJECTIONS] the projection configuration
+     * or list of configurations to be prepped. If ommitted, this function will prep all default projections
      * - code - {string} the identifier for this projection
      * - proj4Def - {string} the proj4js definition
      * - extent - {array} valid extents for this projection [minx, miny, maxx, maxy]
@@ -235,21 +237,31 @@ export default class MapUtil {
      * @returns {object} the openlayers projection object for the default projection
      * @memberof MapUtil
      */
-    static prepProjection(projection = appConfig.DEFAULT_PROJECTION) {
-        // define the projection for this application and reproject defaults
+    static prepProjection(projectionList = appConfig.DEFAULT_AVAILABLE_PROJECTIONS) {
+        // assign the proj4js instance to openlayers
         Ol_Proj.setProj4(proj4js);
 
-        // add configured projection
-        let projDef = proj4js.defs(projection.code);
-        if (typeof proj4Def === "undefined") {
-            proj4js.defs(projection.code, projection.proj4Def);
-            Ol_Proj.get(projection.code).setExtent(projection.extent);
+        // make sure we're using a list
+        if (!(projectionList instanceof Array)) {
+            projectionList = [projectionList];
         }
 
-        // load aliases
-        if (typeof projection.aliases !== "undefined") {
-            for (let i = 0; i < projection.aliases.length; ++i) {
-                proj4js.defs(projection.aliases[i], proj4js.defs(projection.code));
+        // prep all specified projections
+        for (let i = 0; i < projectionList.length; ++i) {
+            let projection = projectionList[i];
+
+            // add configured projection
+            let projDef = proj4js.defs(projection.code);
+            if (typeof proj4Def === "undefined") {
+                proj4js.defs(projection.code, projection.proj4Def);
+                Ol_Proj.get(projection.code).setExtent(projection.extent);
+            }
+
+            // load aliases
+            if (typeof projection.aliases !== "undefined") {
+                for (let i = 0; i < projection.aliases.length; ++i) {
+                    proj4js.defs(projection.aliases[i], proj4js.defs(projection.code));
+                }
             }
         }
 

--- a/src/_core/utils/MapWrapperCesium.js
+++ b/src/_core/utils/MapWrapperCesium.js
@@ -1751,7 +1751,10 @@ export default class MapWrapperCesium extends MapWrapper {
      * @memberof MapWrapperCesium
      */
     createTilingScheme(options, tileSchemeOptions) {
-        if (options.projection === appStrings.PROJECTIONS.latlon.code) {
+        if (
+            options.projection === appStrings.PROJECTIONS.latlon.code ||
+            appStrings.PROJECTIONS.latlon.aliases.indexOf(options.projection) !== -1
+        ) {
             if (options.handleAs === appStrings.LAYER_GIBS_RASTER) {
                 return new CesiumTilingScheme_GIBS(
                     { numberOfLevelZeroTilesX: 2, numberOfLevelZeroTilesY: 1 },
@@ -1759,7 +1762,10 @@ export default class MapWrapperCesium extends MapWrapper {
                 );
             }
             return new this.cesium.GeographicTilingScheme();
-        } else if (options.projection === appStrings.PROJECTIONS.webmercator.code) {
+        } else if (
+            options.projection === appStrings.PROJECTIONS.webmercator.code ||
+            appStrings.PROJECTIONS.webmercator.aliases.indexOf(options.projection) !== -1
+        ) {
             return new this.cesium.WebMercatorTilingScheme();
         }
         return false;

--- a/src/_core/utils/MapWrapperOpenlayers.js
+++ b/src/_core/utils/MapWrapperOpenlayers.js
@@ -2219,7 +2219,7 @@ export default class MapWrapperOpenlayers extends MapWrapper {
             tileGrid: new Ol_Tilegrid_WMTS({
                 extent: options.extents,
                 origin: options.tileGrid.origin,
-                resolutions: resolutions.slice(2, options.tileGrid.resolutions.length), // top two zoom levels are misaligned
+                resolutions: resolutions.slice(2, options.tileGrid.matrixIds.length), // top two zoom levels are misaligned
                 matrixIds: options.tileGrid.matrixIds.slice(2),
                 tileSize: options.tileGrid.tileSize
             }),

--- a/src/default-data/_core_default-data/capabilities.xml
+++ b/src/default-data/_core_default-data/capabilities.xml
@@ -260,7 +260,7 @@
         </Layer>
         <TileMatrixSet>
             <ows:Identifier>2km</ows:Identifier>
-            <ows:SupportedCRS>EPSG:4326</ows:SupportedCRS>
+            <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>223632905.6114871</ScaleDenominator>
@@ -318,7 +318,7 @@
         </TileMatrixSet>
         <TileMatrixSet>
             <ows:Identifier>1km</ows:Identifier>
-            <ows:SupportedCRS>EPSG:4326</ows:SupportedCRS>
+            <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>223632905.6114871</ScaleDenominator>
@@ -385,7 +385,7 @@
         </TileMatrixSet>
         <TileMatrixSet>
             <ows:Identifier>500m</ows:Identifier>
-            <ows:SupportedCRS>EPSG:4326</ows:SupportedCRS>
+            <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>223632905.6114871</ScaleDenominator>
@@ -461,7 +461,7 @@
         </TileMatrixSet>
         <TileMatrixSet>
             <ows:Identifier>250m</ows:Identifier>
-            <ows:SupportedCRS>EPSG:4326</ows:SupportedCRS>
+            <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>223632905.6114871</ScaleDenominator>
@@ -546,7 +546,7 @@
         </TileMatrixSet>
         <TileMatrixSet>
             <ows:Identifier>31.25m</ows:Identifier>
-            <ows:SupportedCRS>EPSG:4326</ows:SupportedCRS>
+            <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>223632905.6114871</ScaleDenominator>


### PR DESCRIPTION
Fixes `prepProjection` to handle built-in projections like webmercator and latlon, adds projection alias support, adds south polar projection definition, moves call to `prepProjection` so that its not dependent on a wmts config, and improves use of recalculated GIBS wmts resolutions