### PR TITLE
loosen restriction on displayMin/displayMax for colorbars

### DIFF
--- a/src/_core/components/Colorbar/Colorbar.js
+++ b/src/_core/components/Colorbar/Colorbar.js
@@ -64,8 +64,8 @@ Colorbar.propTypes = {
     min: PropTypes.number,
     max: PropTypes.number,
     units: PropTypes.string,
-    displayMin: PropTypes.number,
-    displayMax: PropTypes.number,
+    displayMin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    displayMax: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     handleAs: PropTypes.string,
     url: PropTypes.string,
     className: PropTypes.string

--- a/src/_core/components/LayerMenu/LayerControlContainer.js
+++ b/src/_core/components/LayerMenu/LayerControlContainer.js
@@ -161,8 +161,8 @@ export class LayerControlContainer extends Component {
                             min={parseFloat(this.props.layer.get("min"))}
                             max={parseFloat(this.props.layer.get("max"))}
                             units={this.props.layer.get("units")}
-                            displayMin={parseFloat(this.props.layer.getIn(["palette", "min"]))}
-                            displayMax={parseFloat(this.props.layer.getIn(["palette", "max"]))}
+                            displayMin={this.props.layer.getIn(["palette", "min"])}
+                            displayMax={this.props.layer.getIn(["palette", "max"])}
                             handleAs={this.props.layer.getIn(["palette", "handleAs"])}
                             url={this.props.layer.getIn(["palette", "url"])}
                             className={styles.colorbar}


### PR DESCRIPTION
This will allow a layer config to specify a string to display for the colorbar min/max instead of just a number. So `"<= 33"` instead of just `33`