### PR TITLE
Fix polygon area measurement calculation.

### DIFF
--- a/src/_core/utils/MapUtil.js
+++ b/src/_core/utils/MapUtil.js
@@ -701,7 +701,7 @@ export default class MapUtil {
             }
         } else if (measurementType === appStrings.MEASURE_AREA) {
             if (geometry.type === appStrings.GEOMETRY_POLYGON) {
-                return this.calculatePolygonArea(coords, geometry.proj);
+                return this.calculatePolygonArea(coords, appStrings.PROJECTIONS.latlon.code);
             } else {
                 console.warn(
                     "Error in MapUtil.measureGeometry: Could not measure area, unsupported geometry type: ",


### PR DESCRIPTION
The geometry's projection was being used for area calculation instead of latLon (the projection of the coordinates we have at that point).