### PR TITLE
More drawing geometry: Point, Line, Box

### DIFF
--- a/src/_core/components/Map/MapContainer2D.js
+++ b/src/_core/components/Map/MapContainer2D.js
@@ -57,6 +57,16 @@ export class MapContainer2D extends Component {
                 geometry => this.handleDrawEnd(geometry),
                 appStrings.INTERACTION_DRAW
             );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_LINE,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_BOX,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
 
             // measurement listeners
             map.addDrawHandler(

--- a/src/_core/components/Map/MapContainer2D.js
+++ b/src/_core/components/Map/MapContainer2D.js
@@ -52,6 +52,11 @@ export class MapContainer2D extends Component {
                 geometry => this.handleDrawEnd(geometry),
                 appStrings.INTERACTION_DRAW
             );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_POINT,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
 
             // measurement listeners
             map.addDrawHandler(

--- a/src/_core/components/Map/MapContainer3D.js
+++ b/src/_core/components/Map/MapContainer3D.js
@@ -52,6 +52,21 @@ export class MapContainer3D extends Component {
                 geometry => this.handleDrawEnd(geometry),
                 appStrings.INTERACTION_DRAW
             );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_POINT,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_LINE,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
+            map.addDrawHandler(
+                appStrings.GEOMETRY_BOX,
+                geometry => this.handleDrawEnd(geometry),
+                appStrings.INTERACTION_DRAW
+            );
 
             // measurement listeners
             map.addDrawHandler(

--- a/src/_core/components/MouseFollower/DrawingTooltip.js
+++ b/src/_core/components/MouseFollower/DrawingTooltip.js
@@ -22,14 +22,24 @@ export class DrawingTooltip extends Component {
             beginHint = "Click to start measuring";
             referenceGroup = this.props.measuring;
         }
+        let geometryType = referenceGroup.get("geometryType");
 
         // set the hint to complete
-        if (referenceGroup.get("geometryType") === appStrings.GEOMETRY_CIRCLE) {
+        if (
+            geometryType === appStrings.GEOMETRY_CIRCLE ||
+            geometryType === appStrings.GEOMETRY_BOX
+        ) {
             endHint = "Press enter or click to complete";
-        } else if (referenceGroup.get("geometryType") === appStrings.GEOMETRY_LINE_STRING) {
+        } else if (
+            geometryType === appStrings.GEOMETRY_LINE_STRING ||
+            geometryType === appStrings.GEOMETRY_POLYGON
+        ) {
             endHint = "Press enter or double-click to complete";
-        } else if (referenceGroup.get("geometryType") === appStrings.GEOMETRY_POLYGON) {
-            endHint = "Press enter or double-click to complete";
+        } else if (geometryType === appStrings.GEOMETRY_LINE) {
+            endHint = "Click again to complete";
+        } else if (geometryType === appStrings.GEOMETRY_POINT) {
+            beginHint = "Click to draw a point";
+            endHint = "";
         }
 
         let containerClasses = MiscUtil.generateStringFromSet({

--- a/src/_core/components/Reusables/CustomIcons.js
+++ b/src/_core/components/Reusables/CustomIcons.js
@@ -112,3 +112,16 @@ let LayerIconBottom = pure(props => (
 ));
 LayerIconBottom.muiName = "SvgIcon";
 export { LayerIconBottom };
+
+let DrawLineIcon = pure(props => (
+    <SvgIcon {...props}>
+        <svg viewBox="0 0 24 24" style={{ height: "93%" }}>
+            <path
+                fillRule="evenodd"
+                d="M15,3V7.59L7.59,15H3V21H9V16.42L16.42,9H21V3M17,5H19V7H17M5,17H7V19H5"
+            />
+        </svg>
+    </SvgIcon>
+));
+DrawLineIcon.muiName = "SvgIcon";
+export { DrawLineIcon };

--- a/src/_core/components/Reusables/MapToolsMenu.js
+++ b/src/_core/components/Reusables/MapToolsMenu.js
@@ -157,10 +157,42 @@ export class MapToolsMenu extends Component {
                         >
                             <ListItemIcon classes={{ root: styles.listItemIcon }}>
                                 <Icon>
-                                    <i className="ms ms-polygon" />
+                                    <i className="ms ms-points" />
                                 </Icon>
                             </ListItemIcon>
                             <ListItemText inset primary="Point" />
+                        </MenuItem>
+                        <MenuItem
+                            className={styles.contextMenuItem}
+                            dense
+                            aria-label="Line"
+                            onClick={() => {
+                                this.props.handleRequestClose();
+                                this.props.mapActions.enableDrawing(appStrings.GEOMETRY_LINE);
+                            }}
+                        >
+                            <ListItemIcon classes={{ root: styles.listItemIcon }}>
+                                <Icon>
+                                    <i className="ms ms-line" />
+                                </Icon>
+                            </ListItemIcon>
+                            <ListItemText inset primary="Line" />
+                        </MenuItem>
+                        <MenuItem
+                            className={styles.contextMenuItem}
+                            dense
+                            aria-label="Box"
+                            onClick={() => {
+                                this.props.handleRequestClose();
+                                this.props.mapActions.enableDrawing(appStrings.GEOMETRY_BOX);
+                            }}
+                        >
+                            <ListItemIcon classes={{ root: styles.listItemIcon }}>
+                                <Icon>
+                                    <i className="ms ms-vector" />
+                                </Icon>
+                            </ListItemIcon>
+                            <ListItemText inset primary="Box" />
                         </MenuItem>
                         <Divider />
                         <MenuItem

--- a/src/_core/components/Reusables/MapToolsMenu.js
+++ b/src/_core/components/Reusables/MapToolsMenu.js
@@ -25,6 +25,7 @@ import * as appStrings from "_core/constants/appStrings";
 import * as mapActions from "_core/actions/mapActions";
 import * as appActions from "_core/actions/appActions";
 import { ContextMenuSubMenu } from "_core/components/Reusables";
+import { DrawLineIcon } from "_core/components/Reusables/CustomIcons";
 import styles from "_core/components/Reusables/MapToolsMenu.scss";
 
 export class MapToolsMenu extends Component {
@@ -115,6 +116,20 @@ export class MapToolsMenu extends Component {
                         <MenuItem
                             className={styles.contextMenuItem}
                             dense
+                            aria-label="Line"
+                            onClick={() => {
+                                this.props.handleRequestClose();
+                                this.props.mapActions.enableDrawing(appStrings.GEOMETRY_LINE);
+                            }}
+                        >
+                            <ListItemIcon classes={{ root: styles.listItemIcon }}>
+                                <DrawLineIcon />
+                            </ListItemIcon>
+                            <ListItemText inset primary="Line" />
+                        </MenuItem>
+                        <MenuItem
+                            className={styles.contextMenuItem}
+                            dense
                             aria-label="Polyline"
                             onClick={() => {
                                 this.props.handleRequestClose();
@@ -161,22 +176,6 @@ export class MapToolsMenu extends Component {
                                 </Icon>
                             </ListItemIcon>
                             <ListItemText inset primary="Point" />
-                        </MenuItem>
-                        <MenuItem
-                            className={styles.contextMenuItem}
-                            dense
-                            aria-label="Line"
-                            onClick={() => {
-                                this.props.handleRequestClose();
-                                this.props.mapActions.enableDrawing(appStrings.GEOMETRY_LINE);
-                            }}
-                        >
-                            <ListItemIcon classes={{ root: styles.listItemIcon }}>
-                                <Icon>
-                                    <i className="ms ms-line" />
-                                </Icon>
-                            </ListItemIcon>
-                            <ListItemText inset primary="Line" />
                         </MenuItem>
                         <MenuItem
                             className={styles.contextMenuItem}

--- a/src/_core/components/Reusables/MapToolsMenu.js
+++ b/src/_core/components/Reusables/MapToolsMenu.js
@@ -146,6 +146,22 @@ export class MapToolsMenu extends Component {
                             </ListItemIcon>
                             <ListItemText inset primary="Polygon" />
                         </MenuItem>
+                        <MenuItem
+                            className={styles.contextMenuItem}
+                            dense
+                            aria-label="Point"
+                            onClick={() => {
+                                this.props.handleRequestClose();
+                                this.props.mapActions.enableDrawing(appStrings.GEOMETRY_POINT);
+                            }}
+                        >
+                            <ListItemIcon classes={{ root: styles.listItemIcon }}>
+                                <Icon>
+                                    <i className="ms ms-polygon" />
+                                </Icon>
+                            </ListItemIcon>
+                            <ListItemText inset primary="Point" />
+                        </MenuItem>
                         <Divider />
                         <MenuItem
                             className={styles.contextMenuItem}

--- a/src/_core/constants/appStrings.js
+++ b/src/_core/constants/appStrings.js
@@ -63,6 +63,7 @@ export const CATS_TILE_CS = "catsTile_CS";
 export const GEOMETRY_CIRCLE = "Circle";
 export const GEOMETRY_LINE_STRING = "LineString";
 export const GEOMETRY_POLYGON = "Polygon";
+export const GEOMETRY_POINT = "Point";
 
 // measurement types
 export const MEASURE_DISTANCE = "Distance";

--- a/src/_core/constants/appStrings.js
+++ b/src/_core/constants/appStrings.js
@@ -64,6 +64,18 @@ export const GEOMETRY_CIRCLE = "Circle";
 export const GEOMETRY_LINE_STRING = "LineString";
 export const GEOMETRY_POLYGON = "Polygon";
 export const GEOMETRY_POINT = "Point";
+export const GEOMETRY_LINE = "Line";
+export const GEOMETRY_BOX = "Box";
+
+// map of CMC geometry types to OpenLayers geometry types
+export const OL_GEOMETRY_TYPES = {
+    [GEOMETRY_CIRCLE]: GEOMETRY_CIRCLE,
+    [GEOMETRY_LINE_STRING]: GEOMETRY_LINE_STRING,
+    [GEOMETRY_POLYGON]: GEOMETRY_POLYGON,
+    [GEOMETRY_POINT]: GEOMETRY_POINT,
+    [GEOMETRY_LINE]: GEOMETRY_LINE_STRING,
+    [GEOMETRY_BOX]: GEOMETRY_CIRCLE
+};
 
 // measurement types
 export const MEASURE_DISTANCE = "Distance";

--- a/src/_core/tests/store.map.spec.js
+++ b/src/_core/tests/store.map.spec.js
@@ -1605,10 +1605,7 @@ export const StoreMapSpec = {
                         mapActions.addGeometryToMap(geometryBox, appStrings.INTERACTION_DRAW),
                         mapActions.addGeometryToMap(geometryLine, appStrings.INTERACTION_DRAW)
                     ];
-                    finalActions.forEach(action => {
-                        console.log(action);
-                        store.dispatch(action);
-                    });
+                    finalActions.forEach(action => store.dispatch(action));
 
                     const actual = store.getState();
 

--- a/src/_core/tests/store.map.spec.js
+++ b/src/_core/tests/store.map.spec.js
@@ -908,7 +908,7 @@ export const StoreMapSpec = {
             },
 
             test21: () => {
-                it("can enable drawing a line on a 2D map", function() {
+                it("can enable drawing a line string on a 2D map", function() {
                     const store = createStore(rootReducer, initialState);
 
                     // initial map
@@ -989,6 +989,126 @@ export const StoreMapSpec = {
                 });
             },
 
+            test22B: () => {
+                it("can enable drawing a point on a 2D map", function() {
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_2D, "map2D"),
+                        mapActions.setMapView({ extent: appConfig.DEFAULT_BBOX_EXTENT }, true),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_2D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap2D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_2D];
+
+                    // add drawing on the map
+                    actualMap2D.addDrawHandler(
+                        appStrings.GEOMETRY_POINT,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_POINT)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], false)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_POINT)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+                });
+            },
+
+            test22C: () => {
+                it("can enable drawing a box on a 2D map", function() {
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_2D, "map2D"),
+                        mapActions.setMapView({ extent: appConfig.DEFAULT_BBOX_EXTENT }, true),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_2D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap2D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_2D];
+
+                    // add drawing on the map
+                    actualMap2D.addDrawHandler(
+                        appStrings.GEOMETRY_BOX,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_BOX)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], false)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_BOX)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+                });
+            },
+
+            test22D: () => {
+                it("can enable drawing a (single) line on a 2D map", function() {
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_2D, "map2D"),
+                        mapActions.setMapView({ extent: appConfig.DEFAULT_BBOX_EXTENT }, true),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_2D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap2D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_2D];
+
+                    // add drawing on the map
+                    actualMap2D.addDrawHandler(
+                        appStrings.GEOMETRY_LINE,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_LINE)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], false)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_LINE)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+                });
+            },
+
             test23: () => {
                 it("can enable drawing a circle on a 3D map", function() {
                     if (TestUtil.skipIfNoWebGL("StoreMapSpec.default.test23", this)) {
@@ -1034,7 +1154,7 @@ export const StoreMapSpec = {
             },
 
             test24: () => {
-                it("can enable drawing a line on a 3D map", function() {
+                it("can enable drawing a line string on a 3D map", function() {
                     if (TestUtil.skipIfNoWebGL("StoreMapSpec.default.test24", this)) {
                         return;
                     }
@@ -1117,6 +1237,138 @@ export const StoreMapSpec = {
                         .setIn(["view", "in3DMode"], true)
                         .setIn(["drawing", "isDrawingEnabled"], true)
                         .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_POLYGON)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+
+                    TestUtil.compareFullStates(actual, expected);
+                });
+            },
+
+            test25B: () => {
+                it("can enable drawing a point on a 3D map", function() {
+                    if (TestUtil.skipIfNoWebGL("StoreMapSpec.default.test25B", this)) {
+                        return;
+                    }
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_3D, "map3D"),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_3D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap3D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_3D];
+
+                    // add drawing on the map
+                    actualMap3D.addDrawHandler(
+                        appStrings.GEOMETRY_POINT,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_POINT)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], true)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_POINT)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+
+                    TestUtil.compareFullStates(actual, expected);
+                });
+            },
+
+            test25C: () => {
+                it("can enable drawing a box on a 3D map", function() {
+                    if (TestUtil.skipIfNoWebGL("StoreMapSpec.default.test25C", this)) {
+                        return;
+                    }
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_3D, "map3D"),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_3D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap3D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_3D];
+
+                    // add drawing on the map
+                    actualMap3D.addDrawHandler(
+                        appStrings.GEOMETRY_BOX,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_BOX)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], true)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_BOX)
+                        .setIn(["measuring", "isMeasuringEnabled"], false);
+
+                    TestUtil.compareFullStates(actual, expected);
+                });
+            },
+
+            test25D: () => {
+                it("can enable drawing a (single) line on a 3D map", function() {
+                    if (TestUtil.skipIfNoWebGL("StoreMapSpec.default.test25D", this)) {
+                        return;
+                    }
+                    const store = createStore(rootReducer, initialState);
+
+                    // initial map
+                    const initalActions = [
+                        mapActions.initializeMap(appStrings.MAP_LIB_3D, "map3D"),
+                        mapActions.setMapViewMode(appStrings.MAP_VIEW_MODE_3D)
+                    ];
+                    initalActions.forEach(action => store.dispatch(action));
+
+                    // retrieve map object
+                    const expected = store.getState();
+                    const actualMap3D = expected.map.get("maps").toJS()[appStrings.MAP_LIB_3D];
+
+                    // add drawing on the map
+                    actualMap3D.addDrawHandler(
+                        appStrings.GEOMETRY_LINE,
+                        () => {},
+                        appStrings.INTERACTION_DRAW
+                    );
+
+                    // enable drawing
+                    const finalActions = [mapActions.enableDrawing(appStrings.GEOMETRY_LINE)];
+                    finalActions.forEach(action => store.dispatch(action));
+
+                    const actual = store.getState();
+
+                    actual.map = actual.map.remove("maps");
+
+                    expected.map = expected.map
+                        .remove("maps")
+                        .setIn(["view", "in3DMode"], true)
+                        .setIn(["drawing", "isDrawingEnabled"], true)
+                        .setIn(["drawing", "geometryType"], appStrings.GEOMETRY_LINE)
                         .setIn(["measuring", "isMeasuringEnabled"], false);
 
                     TestUtil.compareFullStates(actual, expected);
@@ -1294,6 +1546,53 @@ export const StoreMapSpec = {
                         id: Math.random()
                     };
 
+                    let geometryPoint = {
+                        type: appStrings.GEOMETRY_POINT,
+                        coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC,
+                        proj: actualMap2D.map
+                            .getView()
+                            .getProjection()
+                            .getCode(),
+                        coordinates: { lat: 35, lon: 29 },
+                        id: Math.random()
+                    };
+
+                    let geometryBox = {
+                        type: appStrings.GEOMETRY_BOX,
+                        coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC,
+                        proj: actualMap2D.map
+                            .getView()
+                            .getProjection()
+                            .getCode(),
+                        coordinates: [
+                            { lon: 20, lat: 30 },
+                            { lon: 30, lat: 30 },
+                            { lon: 30, lat: 10 },
+                            { lon: 20, lat: 10 }
+                        ],
+                        id: Math.random()
+                    };
+
+                    let geometryLine = {
+                        type: appStrings.GEOMETRY_POLYGON,
+                        coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC,
+                        proj: actualMap2D.map
+                            .getView()
+                            .getProjection()
+                            .getCode(),
+                        coordinates: [
+                            {
+                                lon: -12,
+                                lat: -67
+                            },
+                            {
+                                lon: 8,
+                                lat: -45
+                            }
+                        ],
+                        id: Math.random()
+                    };
+
                     // add geometries
                     const finalActions = [
                         mapActions.addGeometryToMap(geometryCircle, appStrings.INTERACTION_DRAW),
@@ -1301,9 +1600,15 @@ export const StoreMapSpec = {
                             geometryLineString,
                             appStrings.INTERACTION_DRAW
                         ),
-                        mapActions.addGeometryToMap(geometryPolygon, appStrings.INTERACTION_DRAW)
+                        mapActions.addGeometryToMap(geometryPolygon, appStrings.INTERACTION_DRAW),
+                        mapActions.addGeometryToMap(geometryPoint, appStrings.INTERACTION_DRAW),
+                        mapActions.addGeometryToMap(geometryBox, appStrings.INTERACTION_DRAW),
+                        mapActions.addGeometryToMap(geometryLine, appStrings.INTERACTION_DRAW)
                     ];
-                    finalActions.forEach(action => store.dispatch(action));
+                    finalActions.forEach(action => {
+                        console.log(action);
+                        store.dispatch(action);
+                    });
 
                     const actual = store.getState();
 
@@ -1324,7 +1629,7 @@ export const StoreMapSpec = {
                     let drawFeatures = mapLayerFeatures.filter(
                         x => x.get("interactionType") === appStrings.INTERACTION_DRAW
                     );
-                    expect(drawFeatures.length).to.equal(3);
+                    expect(drawFeatures.length).to.equal(6);
                     TestUtil.compareFullStates(actual, expected);
                 });
             },

--- a/src/_core/utils/CesiumDrawHelper.js
+++ b/src/_core/utils/CesiumDrawHelper.js
@@ -965,6 +965,25 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
 
         var mouseHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
 
+        const finishDrawing = (includeLastPoint = true) => {
+            _self.stopDrawing();
+            if (typeof options.callback === "function") {
+                // 08/02/16 AARON PLAVE MODIFICATION TO
+                //  ALLOW FOR HIGH ZOOM DRAWING AND
+                //  REMOVAL OF DUPLICATE POINTS
+                // TODO - calculate some epsilon based on the zoom level
+                var epsilon = Cesium.Math.EPSILON8;
+                var newPos = [positions[0]];
+                var lastPointIndex = includeLastPoint ? positions.length - 1 : positions.length - 2;
+                for (var i = 1; i <= lastPointIndex; i++) {
+                    if (!positions[i].equalsEpsilon(positions[i - 1], epsilon)) {
+                        newPos.push(positions[i]);
+                    }
+                }
+                options.callback(newPos.splice(0, newPos.length));
+            }
+        };
+
         // Now wait for start
         mouseHandler.setInputAction(function(movement) {
             if (movement.position != null) {
@@ -989,6 +1008,10 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
                     positions.push(cartesian);
                     // add marker at the new position
                     // markers.addBillboard(cartesian);
+                    // stop drawing if we've hit the max # of points
+                    if (options.maxPoints && positions.length >= options.maxPoints + 1) {
+                        finishDrawing(true);
+                    }
                 }
             }
         }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
@@ -1042,40 +1065,16 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
                 } else {
                     var cartesian = scene.camera.pickEllipsoid(position, ellipsoid);
                     if (cartesian) {
-                        _self.stopDrawing();
-                        if (typeof options.callback == "function") {
-                            // remove overlapping ones
-                            // // TODO - calculate some epsilon based on the zoom level
-                            var index = positions.length - 1;
-                            // 08/02/16 AARON PLAVE MODIFICATION TO
-                            //  ALLOW FOR HIGH ZOOM DRAWING AND
-                            //  REMOVAL OF DUPLICATE POINTS
-                            var epsilon = Cesium.Math.EPSILON8;
-                            var newPos = [positions[0]];
-                            for (var i = 1; i < positions.length; i++) {
-                                if (!positions[i].equalsEpsilon(positions[i - 1], epsilon)) {
-                                    newPos.push(positions[i]);
-                                }
-                            }
-                            options.callback(newPos.splice(0, index + 1));
-                        }
+                        finishDrawing(true);
                     }
                 }
             }
         }, Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
 
         var handleEnter = function(evt) {
-            if (
-                evt.keyCode === 13 &&
-                typeof options.callback == "function" &&
-                positions.length - 1 >= minPoints
-            ) {
-                _self.stopDrawing();
-                var newPos = [];
-                for (var i = 0; i < positions.length - 1; i++) {
-                    newPos.push(positions[i]);
-                }
-                options.callback(newPos.splice(0, newPos.length + 1));
+            if (evt.keyCode === 13 && positions.length - 1 >= minPoints) {
+                // call with false to not include last point (mouse position when pressing enter)
+                finishDrawing(false);
             }
         };
         document.addEventListener("keyup", handleEnter);
@@ -1089,9 +1088,16 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
             Cesium.Rectangle.southwest(value)
         ]);
     }
+    // edited by Dan Delany 9/10 - export getExtentCorners
+    _.prototype.getExtentCorners = getExtentCorners;
 
     _.prototype.startDrawingExtent = function(options) {
         var options = copyOptions(options, defaultSurfaceOptions);
+
+        options.material.uniforms.color = new Cesium.Color.fromCssColorString(
+            this._defaultFillColor
+        );
+        options.strokeColor = new Cesium.Color.fromCssColorString(this._defaultStrokeColor);
 
         this.startDrawing(function() {
             if (extent != null) {
@@ -1106,7 +1112,6 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
         var scene = this._scene;
         var primitives = this._scene.primitives;
         var tooltip = this._tooltip;
-
         var firstPoint = null;
         var extent = null;
         var markers = null;
@@ -1115,11 +1120,18 @@ var DrawHelper = function(base_ellipsoid = Cesium.Ellipsoid.WGS84) {
 
         function updateExtent(value) {
             if (extent == null) {
-                extent = new Cesium.RectanglePrimitive();
+                // modified 9/11/18 by Dan Delany
+                // use ExtentPrimitive because RectanglePrimitive is deprecated
+                //extent = new Cesium.RectanglePrimitive();
+                extent = new DrawHelper.ExtentPrimitive({
+                    ...options,
+                    extent: value,
+                    showDrawingOutline: true
+                });
                 extent.asynchronous = false;
                 primitives.add(extent);
             }
-            extent.rectangle = value;
+            extent.setExtent(value);
             // update the markers
             var corners = getExtentCorners(value);
             // create if they do not yet exist

--- a/src/_core/utils/MapWrapperCesium.js
+++ b/src/_core/utils/MapWrapperCesium.js
@@ -849,31 +849,15 @@ export default class MapWrapperCesium extends MapWrapper {
 
         try {
             if (geometry.type === appStrings.GEOMETRY_CIRCLE) {
-                let cesiumCenter = null;
-                let cesiumRadius = null;
+                let cesiumCenter = geometry.center;
                 // Check coordinate type
                 if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTOGRAPHIC) {
-                    // Calc radius by finding cartesian distance from
-                    // center to radius point
-                    let point = {
-                        lat: geometry.center.lat,
-                        lon: geometry.center.lon
-                    };
-                    point.lon += geometry.radius;
-
                     cesiumCenter = this.latLonToCartesian(geometry.center.lat, geometry.center.lon);
-                    cesiumRadius = this.mapUtil.calculatePolylineDistance(
-                        [[geometry.center.lon, geometry.center.lat], [point.lon, point.lat]],
-                        geometry.proj
-                    );
-                } else {
-                    cesiumCenter = geometry.center;
-                    cesiumRadius = geometry.radius;
                 }
                 const material = getShapeMaterial();
                 let primitiveToAdd = new this.drawHelper.CirclePrimitive({
                     center: cesiumCenter,
-                    radius: cesiumRadius,
+                    radius: geometry.radius,
                     material: material,
                     showDrawingOutline: true
                 });

--- a/src/_core/utils/MapWrapperCesium.js
+++ b/src/_core/utils/MapWrapperCesium.js
@@ -110,6 +110,11 @@ export default class MapWrapperCesium extends MapWrapper {
                 maxZoom: options.getIn(["view", "maxZoomDistance3D"]),
                 minZoom: options.getIn(["view", "minZoomDistance3D"])
             };
+
+            // points collection where drawn points are stored
+            this.pointCollection = this.map.scene.primitives.add(
+                new this.cesium.PointPrimitiveCollection()
+            );
         }
     }
 
@@ -533,22 +538,24 @@ export default class MapWrapperCesium extends MapWrapper {
      */
     addDrawHandler(geometryType, onDrawEnd, interactionType) {
         try {
+            const interactionId = `_id${interactionType}${geometryType}`;
+            const baseGeometry = {
+                proj: appStrings.PROJECTIONS.latlon.code,
+                type: geometryType,
+                id: Math.random()
+            };
+
             if (geometryType === appStrings.GEOMETRY_CIRCLE) {
-                this.drawHandler._customInteractions[
-                    "_id" + interactionType + appStrings.GEOMETRY_CIRCLE
-                ] = () => {
+                this.drawHandler._customInteractions[interactionId] = () => {
                     this.drawHandler.startDrawingCircle({
                         callback: (center, radius) => {
                             // Add geometry to cesium map since it's not done automatically
-                            let id = Math.random();
                             this.addGeometry(
                                 {
-                                    proj: appStrings.PROJECTIONS.latlon.code,
-                                    type: geometryType,
+                                    ...baseGeometry,
                                     center: center,
                                     radius: radius,
-                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN,
-                                    id: id
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
                                 },
                                 interactionType
                             );
@@ -556,10 +563,8 @@ export default class MapWrapperCesium extends MapWrapper {
                                 // Recover geometry from event in cartographic
                                 let cartographicCenter = this.cartesianToLatLon(center);
                                 let geometry = {
-                                    type: appStrings.GEOMETRY_CIRCLE,
+                                    ...baseGeometry,
                                     center: cartographicCenter,
-                                    id: id,
-                                    proj: appStrings.PROJECTIONS.latlon.code,
                                     radius: radius,
                                     coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
                                 };
@@ -569,21 +574,20 @@ export default class MapWrapperCesium extends MapWrapper {
                     });
                 };
                 return true;
-            } else if (geometryType === appStrings.GEOMETRY_LINE_STRING) {
-                this.drawHandler._customInteractions[
-                    "_id" + interactionType + appStrings.GEOMETRY_LINE_STRING
-                ] = () => {
+            } else if (
+                geometryType === appStrings.GEOMETRY_LINE_STRING ||
+                geometryType === appStrings.GEOMETRY_LINE
+            ) {
+                const maxPoints = geometryType === appStrings.GEOMETRY_LINE ? 2 : undefined;
+                this.drawHandler._customInteractions[interactionId] = () => {
                     this.drawHandler.startDrawingPolyline({
                         callback: coordinates => {
                             // Add geometry to cesium map since it's not done automatically
-                            let id = Math.random();
                             this.addGeometry(
                                 {
-                                    proj: appStrings.PROJECTIONS.latlon.code,
-                                    type: geometryType,
+                                    ...baseGeometry,
                                     coordinates: coordinates,
-                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN,
-                                    id: id
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
                                 },
                                 interactionType
                             );
@@ -593,33 +597,27 @@ export default class MapWrapperCesium extends MapWrapper {
                                     return this.cartesianToLatLon(pos);
                                 });
                                 let geometry = {
-                                    type: appStrings.GEOMETRY_LINE_STRING,
-                                    id: id,
-                                    proj: appStrings.PROJECTIONS.latlon.code,
+                                    ...baseGeometry,
                                     coordinates: cartographicCoordinates,
                                     coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
                                 };
                                 onDrawEnd(geometry);
                             }
-                        }
+                        },
+                        maxPoints: maxPoints
                     });
                 };
                 return true;
             } else if (geometryType === appStrings.GEOMETRY_POLYGON) {
-                this.drawHandler._customInteractions[
-                    "_id" + interactionType + appStrings.GEOMETRY_POLYGON
-                ] = () => {
+                this.drawHandler._customInteractions[interactionId] = () => {
                     this.drawHandler.startDrawingPolygon({
                         callback: coordinates => {
                             // Add geometry to cesium map since it's not done automatically
-                            let id = Math.random();
                             this.addGeometry(
                                 {
-                                    proj: appStrings.PROJECTIONS.latlon.code,
-                                    type: geometryType,
+                                    ...baseGeometry,
                                     coordinates: coordinates,
-                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN,
-                                    id: id
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
                                 },
                                 interactionType
                             );
@@ -629,10 +627,8 @@ export default class MapWrapperCesium extends MapWrapper {
                                     return this.cartesianToLatLon(pos);
                                 });
                                 let geometry = {
-                                    type: appStrings.GEOMETRY_POLYGON,
+                                    ...baseGeometry,
                                     coordinates: cartographicCoordinates,
-                                    id: id,
-                                    proj: appStrings.PROJECTIONS.latlon.code,
                                     coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
                                 };
                                 onDrawEnd(geometry);
@@ -641,6 +637,64 @@ export default class MapWrapperCesium extends MapWrapper {
                     });
                 };
                 return true;
+            } else if (geometryType === appStrings.GEOMETRY_POINT) {
+                this.drawHandler._customInteractions[interactionId] = () => {
+                    this.drawHandler.startDrawingMarker({
+                        callback: coordinates => {
+                            // Add geometry to cesium map since it's not done automatically
+                            this.addGeometry(
+                                {
+                                    ...baseGeometry,
+                                    coordinates: coordinates,
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
+                                },
+                                interactionType
+                            );
+                            if (typeof onDrawEnd === "function") {
+                                // Recover geometry from event in cartographic
+                                let cartographicCoordinates = this.cartesianToLatLon(coordinates);
+                                let geometry = {
+                                    ...baseGeometry,
+                                    coordinates: cartographicCoordinates,
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+                                };
+                                onDrawEnd(geometry);
+                            }
+                        }
+                    });
+                };
+                return true;
+            } else if (geometryType === appStrings.GEOMETRY_BOX) {
+                this.drawHandler._customInteractions[interactionId] = () => {
+                    this.drawHandler.startDrawingExtent({
+                        callback: extent => {
+                            const coordinates = this.drawHandler.getExtentCorners(extent);
+                            // Add geometry to cesium map since it's not done automatically
+                            this.addGeometry(
+                                {
+                                    ...baseGeometry,
+                                    extent: extent,
+                                    coordinates: coordinates,
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
+                                },
+                                interactionType
+                            );
+                            if (typeof onDrawEnd === "function") {
+                                // Recover geometry from event in cartographic
+                                let cartographicCoordinates = coordinates.map(pos => {
+                                    return this.cartesianToLatLon(pos);
+                                });
+                                let geometry = {
+                                    ...baseGeometry,
+                                    extent: extent,
+                                    coordinates: cartographicCoordinates,
+                                    coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+                                };
+                                onDrawEnd(geometry);
+                            }
+                        }
+                    });
+                };
             }
             return false;
         } catch (err) {
@@ -760,6 +814,41 @@ export default class MapWrapperCesium extends MapWrapper {
      * @memberof MapWrapperCesium
      */
     addGeometry(geometry, interactionType, geodesic = false) {
+        const getGeomCartesianCoords = (geometry, multiplePoints = true) => {
+            let cartesianCoords = null;
+            // Check coordinate type
+            if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTOGRAPHIC) {
+                // Transform coordinates from cartographic to cartesian
+                if (multiplePoints) {
+                    cartesianCoords = geometry.coordinates.map(x => {
+                        return this.latLonToCartesian(x.lat, x.lon);
+                    });
+                } else {
+                    const rawCoords = geometry.coordinates;
+                    cartesianCoords = this.latLonToCartesian(rawCoords.lat, rawCoords.lon);
+                }
+            } else if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTESIAN) {
+                cartesianCoords = geometry.coordinates;
+            } else {
+                console.warn(
+                    `Unhandled coordinate type when trying to draw cesium ${geometry.type}:`,
+                    geometry.coordinateType
+                );
+                return false;
+            }
+            return cartesianCoords;
+        };
+        const getShapeMaterial = () => {
+            let material = this.cesium.Material.fromType(this.cesium.Material.RimLightingType);
+            material.uniforms.color = new this.cesium.Color.fromCssColorString(
+                appConfig.GEOMETRY_FILL_COLOR
+            );
+            material.uniforms.rimColor = new this.cesium.Color.fromCssColorString(
+                appConfig.GEOMETRY_FILL_COLOR
+            );
+            return material;
+        };
+
         try {
             if (geometry.type === appStrings.GEOMETRY_CIRCLE) {
                 let cesiumCenter = null;
@@ -774,9 +863,7 @@ export default class MapWrapperCesium extends MapWrapper {
                     };
                     point.lon += geometry.radius;
 
-                    let cesiumPoint = this.latLonToCartesian(point.lat, point.lon);
                     cesiumCenter = this.latLonToCartesian(geometry.center.lat, geometry.center.lon);
-                    // cesiumRadius = this.cesium.Cartesian3.distance(cesiumCenter, cesiumPoint);
                     cesiumRadius = this.mapUtil.calculatePolylineDistance(
                         [[geometry.center.lon, geometry.center.lat], [point.lon, point.lat]],
                         geometry.proj
@@ -785,11 +872,7 @@ export default class MapWrapperCesium extends MapWrapper {
                     cesiumCenter = geometry.center;
                     cesiumRadius = geometry.radius;
                 }
-                let material = this.cesium.Material.fromType(this.cesium.Material.RimLightingType);
-                material.uniforms.color = new this.cesium.Color.fromCssColorString(
-                    appConfig.GEOMETRY_FILL_COLOR
-                );
-                material.uniforms.rimColor = new this.cesium.Color(1.0, 1.0, 1.0, 1.0);
+                const material = getShapeMaterial();
                 let primitiveToAdd = new this.drawHelper.CirclePrimitive({
                     center: cesiumCenter,
                     radius: cesiumRadius,
@@ -803,23 +886,11 @@ export default class MapWrapperCesium extends MapWrapper {
                     appConfig.GEOMETRY_STROKE_WEIGHT
                 );
                 return true;
-            } else if (geometry.type === appStrings.GEOMETRY_LINE_STRING) {
-                let cartesianCoords = null;
-                // Check coordinate type
-                if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTOGRAPHIC) {
-                    // Transform coordinates from cartographic to cartesian
-                    cartesianCoords = geometry.coordinates.map(x => {
-                        return this.latLonToCartesian(x.lat, x.lon);
-                    });
-                } else if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTESIAN) {
-                    cartesianCoords = geometry.coordinates;
-                } else {
-                    console.warn(
-                        "Unhandled coordinate type when trying to draw cesium line string:",
-                        geometry.type
-                    );
-                    return false;
-                }
+            } else if (
+                geometry.type === appStrings.GEOMETRY_LINE_STRING ||
+                geometry.type === appStrings.GEOMETRY_LINE
+            ) {
+                let cartesianCoords = getGeomCartesianCoords(geometry, true);
                 let material = this.cesium.Material.fromType(this.cesium.Material.ColorType);
                 material.uniforms.color = new this.cesium.Color.fromCssColorString(
                     appConfig.GEOMETRY_STROKE_COLOR
@@ -836,29 +907,8 @@ export default class MapWrapperCesium extends MapWrapper {
                 this.map.scene.primitives.add(primitiveToAdd);
                 return true;
             } else if (geometry.type === appStrings.GEOMETRY_POLYGON) {
-                let cartesianCoords = null;
-                // Check coordinate type
-                if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTOGRAPHIC) {
-                    // Transform coordinates from cartographic to cartesian
-                    cartesianCoords = geometry.coordinates.map(x => {
-                        return this.latLonToCartesian(x.lat, x.lon);
-                    });
-                } else if (geometry.coordinateType === appStrings.COORDINATE_TYPE_CARTESIAN) {
-                    cartesianCoords = geometry.coordinates;
-                } else {
-                    console.warn(
-                        "Unhandled coordinate type when trying to draw cesium polygon string:",
-                        geometry.type
-                    );
-                    return false;
-                }
-                let material = this.cesium.Material.fromType(this.cesium.Material.RimLightingType);
-                material.uniforms.color = new this.cesium.Color.fromCssColorString(
-                    appConfig.GEOMETRY_FILL_COLOR
-                );
-                material.uniforms.rimColor = new this.cesium.Color.fromCssColorString(
-                    appConfig.GEOMETRY_FILL_COLOR
-                );
+                const cartesianCoords = getGeomCartesianCoords(geometry, true);
+                const material = getShapeMaterial();
                 let primitiveToAdd = new this.drawHelper.PolygonPrimitive({
                     positions: cartesianCoords,
                     material: material,
@@ -871,7 +921,36 @@ export default class MapWrapperCesium extends MapWrapper {
                     appConfig.GEOMETRY_STROKE_WEIGHT
                 );
                 return true;
+            } else if (geometry.type === appStrings.GEOMETRY_POINT) {
+                let cartesianCoords = getGeomCartesianCoords(geometry, false);
+                const pointPrimitive = new this.cesium.PointPrimitive({
+                    position: cartesianCoords,
+                    color: new this.cesium.Color.fromCssColorString(
+                        appConfig.GEOMETRY_STROKE_COLOR
+                    ),
+                    outlineColor: new this.cesium.Color(0.0, 0.0, 0.0, 1.0),
+                    outlineWeight: appConfig.GEOMETRY_STROKE_WEIGHT,
+                    pixelSize: 8.0
+                });
+                // add to our persistent PointPrimitiveCollection
+                this.pointCollection.add(pointPrimitive);
+                return true;
+            } else if (geometry.type === appStrings.GEOMETRY_BOX) {
+                const material = getShapeMaterial();
+                const primitive = new this.drawHelper.ExtentPrimitive({
+                    extent: geometry.extent,
+                    material: material,
+                    showDrawingOutline: true
+                });
+                primitive._interactionType = interactionType;
+                primitive.setStrokeStyle(
+                    new this.cesium.Color.fromCssColorString(appConfig.GEOMETRY_STROKE_COLOR),
+                    appConfig.GEOMETRY_STROKE_WEIGHT
+                );
+                this.map.scene.primitives.add(primitive);
+                return true;
             }
+
             console.warn("add geometry not complete in cesium", geometry, " is unsupported");
             return false;
         } catch (err) {
@@ -983,6 +1062,8 @@ export default class MapWrapperCesium extends MapWrapper {
             for (let i = 0; i < primitivesToRemove.length; i++) {
                 this.map.scene.primitives.remove(primitivesToRemove[i]);
             }
+            // also remove all points from point primitive collection
+            this.pointCollection.removeAll();
             return (
                 this.map.scene.primitives._primitives.filter(
                     x => x._interactionType === appStrings.INTERACTION_DRAW

--- a/src/_core/utils/MapWrapperCesium.js
+++ b/src/_core/utils/MapWrapperCesium.js
@@ -673,7 +673,6 @@ export default class MapWrapperCesium extends MapWrapper {
                             this.addGeometry(
                                 {
                                     ...baseGeometry,
-                                    extent: extent,
                                     coordinates: coordinates,
                                     coordinateType: appStrings.COORDINATE_TYPE_CARTESIAN
                                 },
@@ -686,7 +685,6 @@ export default class MapWrapperCesium extends MapWrapper {
                                 });
                                 let geometry = {
                                     ...baseGeometry,
-                                    extent: extent,
                                     coordinates: cartographicCoordinates,
                                     coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
                                 };
@@ -906,7 +904,10 @@ export default class MapWrapperCesium extends MapWrapper {
                 primitiveToAdd._interactionType = interactionType;
                 this.map.scene.primitives.add(primitiveToAdd);
                 return true;
-            } else if (geometry.type === appStrings.GEOMETRY_POLYGON) {
+            } else if (
+                geometry.type === appStrings.GEOMETRY_POLYGON ||
+                geometry.type === appStrings.GEOMETRY_BOX
+            ) {
                 const cartesianCoords = getGeomCartesianCoords(geometry, true);
                 const material = getShapeMaterial();
                 let primitiveToAdd = new this.drawHelper.PolygonPrimitive({
@@ -934,20 +935,6 @@ export default class MapWrapperCesium extends MapWrapper {
                 });
                 // add to our persistent PointPrimitiveCollection
                 this.pointCollection.add(pointPrimitive);
-                return true;
-            } else if (geometry.type === appStrings.GEOMETRY_BOX) {
-                const material = getShapeMaterial();
-                const primitive = new this.drawHelper.ExtentPrimitive({
-                    extent: geometry.extent,
-                    material: material,
-                    showDrawingOutline: true
-                });
-                primitive._interactionType = interactionType;
-                primitive.setStrokeStyle(
-                    new this.cesium.Color.fromCssColorString(appConfig.GEOMETRY_STROKE_COLOR),
-                    appConfig.GEOMETRY_STROKE_WEIGHT
-                );
-                this.map.scene.primitives.add(primitive);
                 return true;
             }
 

--- a/src/_core/utils/MapWrapperOpenlayers.js
+++ b/src/_core/utils/MapWrapperOpenlayers.js
@@ -1258,6 +1258,8 @@ export default class MapWrapperOpenlayers extends MapWrapper {
                         shapeType = appStrings.SHAPE_AREA;
                     } else if (geometryType === appStrings.GEOMETRY_CIRCLE) {
                         shapeType = appStrings.SHAPE_DISTANCE;
+                    } else if (geometryType === appStrings.GEOMETRY_POINT) {
+                        shapeType = appStrings.SHAPE_DISTANCE;
                     }
                 }
                 let drawStyle = (feature, resolution) => {
@@ -1328,18 +1330,29 @@ export default class MapWrapperOpenlayers extends MapWrapper {
      * @memberof MapWrapperOpenlayers
      */
     retrieveGeometryFromEvent(event, geometryType) {
+        // Base attributes common to all geometry types
+        const baseGeometry = {
+            type: geometryType,
+            id: Math.random(),
+            proj: this.map
+                .getView()
+                .getProjection()
+                .getCode(),
+            coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+        };
+
         if (geometryType === appStrings.GEOMETRY_CIRCLE) {
             let center = event.feature.getGeometry().getCenter();
             return {
-                type: appStrings.GEOMETRY_CIRCLE,
-                id: Math.random(),
+                ...baseGeometry,
                 center: { lon: center[0], lat: center[1] },
-                radius: event.feature.getGeometry().getRadius(),
-                proj: this.map
-                    .getView()
-                    .getProjection()
-                    .getCode(),
-                coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+                radius: event.feature.getGeometry().getRadius()
+            };
+        } else if (geometryType === appStrings.GEOMETRY_POINT) {
+            const coords = event.feature.getGeometry().getCoordinates();
+            return {
+                ...baseGeometry,
+                coordinates: { lon: coords[0], lat: coords[1] }
             };
         } else if (geometryType === appStrings.GEOMETRY_LINE_STRING) {
             let tmpCoords = [];
@@ -1359,14 +1372,8 @@ export default class MapWrapperOpenlayers extends MapWrapper {
                     });
             }
             return {
-                type: appStrings.GEOMETRY_LINE_STRING,
-                id: Math.random(),
-                proj: this.map
-                    .getView()
-                    .getProjection()
-                    .getCode(),
-                coordinates: tmpCoords,
-                coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+                ...baseGeometry,
+                coordinates: tmpCoords
             };
         } else if (geometryType === appStrings.GEOMETRY_POLYGON) {
             let tmpCoords = [];
@@ -1386,14 +1393,8 @@ export default class MapWrapperOpenlayers extends MapWrapper {
                     });
             }
             return {
-                type: appStrings.GEOMETRY_POLYGON,
-                id: Math.random(),
-                proj: this.map
-                    .getView()
-                    .getProjection()
-                    .getCode(),
-                coordinates: tmpCoords,
-                coordinateType: appStrings.COORDINATE_TYPE_CARTOGRAPHIC
+                ...baseGeometry,
+                coordinates: tmpCoords
             };
         }
 


### PR DESCRIPTION
This PR adds 3 new types of map geometry - Point, Line, and Box - which can be drawn by the user or added to the map programmatically with `addGeometry()`. A few notes:

* Line is just a LineString where the user is limited to drawing 2 points
* Box is a rectangle with sides that are north/south/east/west
* Cesium has the notion of an "extent" with north/south/east/west bounds; however, I decided to implement Box internally as a polygon instead, for simplicity and consistency with the other geometries which use vertex `coordinates`.

**ALSO:** While implementing this, I realized that the `addGeometry` function for Circles was inconsistent between the Cesium and OpenLayers map wrappers: the OpenLayers wrapper interpreted the `radius` value as being in meters, while the Cesium wrapper interpreted it as degrees of longitude. I discussed this with @AaronPlave  and we decided meters made more sense, so I've changed the OpenLayers wrapper to use meters. Not sure if this would be considered a breaking change for someone using the API or just a bugfix?