### PR TITLE
Update webpack extension resolver to prioritize JS files over others

### DIFF
--- a/webpack/webpack.config.helper.js
+++ b/webpack/webpack.config.helper.js
@@ -139,7 +139,7 @@ module.exports = options => {
         ],
         resolve: {
             modules: [path.join(BASE_DIR, "src"), path.join(BASE_DIR, "assets"), "node_modules"], // Tell webpack to look for imports using these prefixes
-            extensions: [".jsx", ".scss", ".css", ".js", ".json", ".md"], // Tell webpack that these extensions are optionally specified in the import statements
+            extensions: [".js", ".jsx", ".json", ".scss", ".css", ".md"], // Tell webpack that these extensions are optionally specified in the import statements
             alias: {
                 modernizr$: path.join(BASE_DIR, "lib/modernizr/.modernizrrc.js")
             }


### PR DESCRIPTION
I ran into a bit of confusing behavior today regarding webpack's automatic extension resolution. Here's what I did:

1. Created a new component called `MyThing.js`
2. Imported it in another component using `import MyThing from './MyThing'`. Works fine.
3. Created a SASS stylesheet for my component called `MyThing.scss`
4. Refreshed the page... all of a sudden nothing is working and I'm getting React errors!

After a bit of digging, I realized the Webpack config `resolve.extensions` lists `.scss` before `.js` - so if you import a `Thing` without an extension, and `Thing.js` & `Thing.scss` both exist, the .scss file will be imported. I think this is unexpected behavior - generally extensionless import implies `.js` (or `.jsx`) and `.scss` imports explicitly include the extension.

This PR reorders the extension list to put `.js` and `.jsx` at the beginning of the list.